### PR TITLE
Update ensembling.py

### DIFF
--- a/baseline/trans/ensembling.py
+++ b/baseline/trans/ensembling.py
@@ -12,7 +12,7 @@ from trans import utils
 def read_files(fileobj: TextIO):
     samples = []
     for line in fileobj:
-        input_, prediction = line.rstrip().split("\t", 1)
+        input_, prediction = line.rstrip("\n").split("\t", 1)
         samples.append(utils.Sample(input_, prediction))
     return samples
 


### PR DESCRIPTION
fix reader crash for empty output predictions

At least in English high there was an empty prediction for "beauregard" in one model that crashed the baseline's majority ensemble script.