### PR TITLE
Sweep flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,37 +128,36 @@ This year's baseline is a ensembled neural transition system based on the
 imitation learning paradigm introduced by Makarov & Clematide (2018). A variant
 of this system (Makarov & Clematide 2020) was the second-best system overall in
 the 2020 shared task (Gorman et al. 2020). Code for the baseline library can be
-found in the [`baseline`](baseline) directory. Baseline development set results
-are given below.
+found in the [`baseline`](baseline) directory. Baseline results are given below.
 
-|                        |  WER (dev) |
-|:-----------------------|-----------:|
-| `eng_us`               |    45.13   |
-| **Subtask 1 (high)**   |  **45.13** |
-|                        |            |
-| `arm_e`                |    4.60    |
-| `bul`	                 |    8.10    |
-| `dut`                  |    9.80    |
-| `fre`                  |    7.40    |
-| `geo`                  |    0.00    |
-| `hbs_latn`             |   35.00    |
-| `hun`                  |    1.60    |
-| `jpn_hira`             |    6.20    |
-| `kor`                  |   18.00    |
-| `vie_hanoi`            |    1.30    |
-| **Subtask 2 (medium)** |  **9.20**  |
-|                        |            |
-| `ady`                  |   22.00    |
-| `gre`                  |    3.00    |
-| `ice`                  |   14.00    |
-| `ita`                  |   25.00    |
-| `khm`                  |   38.00    |
-| `lav`                  |   35.00    |
-| `mlt_latn` 	         |   20.00    |
-| `rum`                  |   10.00    |
-| `slv`                  |   41.00    |
-| `wel_sw`               |   16.00    |
-| **Subtask 3 (low)**    | **22.40**  |
+|                        | WER (dev) | WER (test) |
+|:-----------------------|----------:|-----------:|
+| `eng_us`               |   45.13   |    41.94   |
+| **Subtask 1 (high)**   | **45.13** |  **41.94** |
+|                        |           |            |
+| `arm_e`                |    4.50   |     7.00   |
+| `bul`                  |    8.30   |    18.30   |
+| `dut`                  |   10.80   |    14.70   |
+| `fre`                  |    7.40   |     8.50   |
+| `geo`                  |    0.00   |     0.00   |
+| `hbs_latn`             |   34.70   |    32.10   |
+| `hun`                  |    1.50   |     1.80   |
+| `jpn_hira`             |    6.20   |     5.20   |
+| `kor`                  |   18.40   |    16.30   |
+| `vie_hanoi`            |    1.30   |     2.50   |
+| **Subtask 2 (medium)** |  **9.35** |  **10.64** |
+|                        |           |            |
+| `ady`                  |   22.00   |    22.00   |
+| `gre`                  |    5.00   |    21.00   |
+| `ice`                  |   11.00   |    12.00   |
+| `ita`                  |   22.00   |    19.00   |
+| `khm`                  |   34.00   |    34.00   |
+| `lav`                  |   41.00   |    55.00   |
+| `mlt_latn`             |   20.00   |    19.00   |
+| `rum`                  |   10.00   |    10.00   |
+| `slv`                  |   43.00   |    49.00   |
+| `wel_sw`               |   16.00   |    10.00   |  
+| **Subtask 3 (low)**    | **22.40** |  **25.10** |
 
 ## Comparison with the 2020 shared task
 

--- a/baseline/sweep
+++ b/baseline/sweep
@@ -14,14 +14,26 @@ readonly PATIENCE=12
 readonly SED_EM_ITERATIONS=10
 readonly MAX_ENSEMBLE_SIZE=10
 
+LANGS=""
+
 train() {
     for LEVEL in low medium high; do
         for TRAIN in "${DATA}/${LEVEL}/"*"_train.tsv"; do
-            DEV="${TRAIN//_train.tsv/_dev.tsv}"
-            # TODO(kbg): Change path to .tsv when test data becomes available.
-            TEST="${TRAIN//_train.tsv/_test.txt}"
             LG="$(basename ${TRAIN} _train.tsv)"
+            if [ ${LANGS} ] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
+                # If we've flagged target languages, we wish to ignore all non-targets.
+                then
+                    continue
+            fi
             for ENSEMBLE_SIZE in $(seq 1 "${MAX_ENSEMBLE_SIZE}"); do
+                OUTPUTPATH="${OUTPUT}/${LEVEL}/${LG}/${ENSEMBLE_SIZE}"
+                if   [ -d ${OUTPUTPATH} ] && [ "$(ls -A ${OUTPUTPATH})" ] && ! [ ${LANGS} ]
+                    # We've already created an instance here. So only would do it again if we're looking for a targeted language.
+                    then
+                        continue
+                fi
+                DEV="${TRAIN//_train.tsv/_dev.tsv}"
+                TEST="${TRAIN//_train.tsv/_test.tsv}"
                 # We apply NFD unicode normalization.
                 python trans/train.py \
                     --dynet-seed="${ENSEMBLE_SIZE}" \
@@ -29,7 +41,7 @@ train() {
                     --dev="${DEV}" \
                     --test="${TEST}" \
                     --sed-em-iterations="${SED_EM_ITERATIONS}" \
-                    --output="${OUTPUT}/${LEVEL}/${LG}/${ENSEMBLE_SIZE}" \
+                    --output="${OUTPUTPATH}" \
                     --epochs="${EPOCHS}" \
                     --beam-width="${BEAM_WIDTH}" \
                     --patience="${PATIENCE}" \
@@ -42,41 +54,92 @@ train() {
 
 ensemble() {
     for LEVEL in low medium high; do
-        # TODO(kbg): Add test ensembles when test data becomes available.
-        for DEV in "${DATA}/${LEVEL}/"*"_dev.tsv"; do
-            LG="$(basename ${DEV} _dev.tsv)"
-            python trans/ensembling.py \
-                --gold="${DATA}/${LEVEL}/${LG}_dev.tsv" \
-                --systems "${OUTPUT}/${LEVEL}/${LG}/"*"/dev_beam${BEAM_WIDTH}.predictions" \
-                --output="${OUTPUT}/${LEVEL}/${LG}/ensemble"
+        for TRAIN in "${DATA}/${LEVEL}/"*"_train.tsv"; do
+            LG="$(basename ${TRAIN} _train.tsv)"
+            if [ ${LANGS} ] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
+                # If we've passed target languages, we wish to ignore all non-targets.
+                then
+                    continue
+            fi
+            OUTPUTPATH="${OUTPUT}/${LEVEL}/${LG}/ensemble"
+            if  [ -d ${OUTPUTPATH} ] && [ "$(ls -A ${OUTPUTPATH})" ] && ! [ ${LANGS} ]
+                # We've already trained on this data up to this ensemble. So no need to do again unless we're looking for a specific language.
+                then
+                    continue
+            fi
+            for SPLIT in dev test; do
+                    python trans/ensembling.py \
+                        --gold="${DATA}/${LEVEL}/${LG}_${SPLIT}.tsv" \
+                        --systems "${OUTPUT}/${LEVEL}/${LG}/"*"/${SPLIT}_beam${BEAM_WIDTH}.predictions" \
+                        --output="${OUTPUTPATH}"
+	        done
         done
     done
 }
 
 evaluate() {
+    # Creates two-column TSV with gold and hypothesis data.
     for LEVEL in low medium high; do
-        # TODO(kbg): Revert to test path when test data becomes available.
-        for DEV in "${DATA}/${LEVEL}/"*"_dev.tsv"; do
-            LG="$(basename ${DEV} _dev.tsv)"
-            paste \
-                "${DEV}" \
-                "${OUTPUT}/${LEVEL}/${LG}/ensemble/dev_${MAX_ENSEMBLE_SIZE}ensemble.predictions" \
-            | cut -f2,4 \
-            > "${OUTPUT}/${LEVEL}/${LG}/ensemble/dev_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
+        for TRAIN in "${DATA}/${LEVEL}/"*"_train.tsv"; do
+            LG="$(basename ${TRAIN} _train.tsv)"
+            for SPLIT in dev test; do
+                paste \
+                "${TRAIN//_train.tsv/_${SPLIT}.tsv}" \
+                    "${OUTPUT}/${LEVEL}/${LG}/ensemble/${SPLIT}_${MAX_ENSEMBLE_SIZE}ensemble.predictions" \
+                    | cut -f2,4 \
+                > "${OUTPUT}/${LEVEL}/${LG}/ensemble/${SPLIT}_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
+            done
         done
-	echo "Level: ${LEVEL}"
-        python ${EVALUATION}/./evaluate_all.py \
-            "${OUTPUT}/${LEVEL}/"*"/ensemble/dev_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
-	echo
+    done
+    
+    # Calls evaluation script.
+    for SPLIT in dev test; do
+        echo "Split: ${SPLIT}"
+        for LEVEL in low medium high; do
+            echo "Level: ${LEVEL}"
+                python ${EVALUATION}/./evaluate_all.py \
+                    "${OUTPUT}/"*"/"*"/ensemble/${SPLIT}_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
+            echo
+        done
     done
 }
 
 main() {
-    rm -rf ${OUTPUT}
-    mkdir "${OUTPUT}"
     train
     ensemble
     evaluate
 }
 
+while getopts "rt:" option; do
+    case "${option}" in 
+        t)
+            # Specifies target language for restraining
+            LANGS=${OPTARG}
+            ;;
+        r)  
+            # Resets entire run. This will delete all prior data. 
+            echo "This will delete all prior data. If you wish to continue, press y."
+            while : ; do
+                read -n 1 k <&1
+                if [[ $k = y ]] ; 
+                    then
+                        printf "\nResetting run."
+                        rm -rf ${OUTPUT}
+                        break
+                else
+                    echo "This will delete all prior data. If you wish to continue, press y."
+                fi
+            done
+            ;;
+    esac
+done
+if [ ! -d "${OUTPUT}" ]
+    # For starting a new run.
+    then
+        mkdir ${OUTPUT}
+fi
+
 main
+
+
+

--- a/baseline/sweep
+++ b/baseline/sweep
@@ -20,14 +20,14 @@ train() {
     for LEVEL in low medium high; do
         for TRAIN in "${DATA}/${LEVEL}/"*"_train.tsv"; do
             LG="$(basename ${TRAIN} _train.tsv)"
-            if [ ${LANGS} ] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
+            if [[ ${LANGS} ]] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
                 # If we've flagged target languages, we wish to ignore all non-targets.
                 then
                     continue
             fi
             for ENSEMBLE_SIZE in $(seq 1 "${MAX_ENSEMBLE_SIZE}"); do
                 OUTPUTPATH="${OUTPUT}/${LEVEL}/${LG}/${ENSEMBLE_SIZE}"
-                if   [ -d ${OUTPUTPATH} ] && [ "$(ls -A ${OUTPUTPATH})" ] && ! [ ${LANGS} ]
+                if   [[ -d ${OUTPUTPATH} ]] && [[ "$(ls -A ${OUTPUTPATH})" ]] && ! [[ ${LANGS} ]]
                     # We've already created an instance here. So only would do it again if we're looking for a targeted language.
                     then
                         continue
@@ -36,15 +36,15 @@ train() {
                 TEST="${TRAIN//_train.tsv/_test.tsv}"
                 # We apply NFD unicode normalization.
                 python trans/train.py \
-                    --dynet-seed="${ENSEMBLE_SIZE}" \
-                    --train="${TRAIN}" \
-                    --dev="${DEV}" \
-                    --test="${TEST}" \
-                    --sed-em-iterations="${SED_EM_ITERATIONS}" \
-                    --output="${OUTPUTPATH}" \
-                    --epochs="${EPOCHS}" \
-                    --beam-width="${BEAM_WIDTH}" \
-                    --patience="${PATIENCE}" \
+                    --dynet-seed "${ENSEMBLE_SIZE}" \
+                    --train "${TRAIN}" \
+                    --dev "${DEV}" \
+                    --test "${TEST}" \
+                    --sed-em-iterations "${SED_EM_ITERATIONS}" \
+                    --output "${OUTPUTPATH}" \
+                    --epochs "${EPOCHS}" \
+                    --beam-width "${BEAM_WIDTH}" \
+                    --patience "${PATIENCE}" \
                     --nfd &
             done
             wait
@@ -56,22 +56,22 @@ ensemble() {
     for LEVEL in low medium high; do
         for TRAIN in "${DATA}/${LEVEL}/"*"_train.tsv"; do
             LG="$(basename ${TRAIN} _train.tsv)"
-            if [ ${LANGS} ] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
+            if [[ ${LANGS} ]] && ! [[ " ${LANGS} " =~ " ${LG} " ]]
                 # If we've passed target languages, we wish to ignore all non-targets.
                 then
                     continue
             fi
             OUTPUTPATH="${OUTPUT}/${LEVEL}/${LG}/ensemble"
-            if  [ -d ${OUTPUTPATH} ] && [ "$(ls -A ${OUTPUTPATH})" ] && ! [ ${LANGS} ]
+            if  [[ -d ${OUTPUTPATH} ]] && [[ "$(ls -A ${OUTPUTPATH})" ]] && ! [[ ${LANGS} ]]
                 # We've already trained on this data up to this ensemble. So no need to do again unless we're looking for a specific language.
                 then
                     continue
             fi
             for SPLIT in dev test; do
                     python trans/ensembling.py \
-                        --gold="${DATA}/${LEVEL}/${LG}_${SPLIT}.tsv" \
+                        --gold "${DATA}/${LEVEL}/${LG}_${SPLIT}.tsv" \
                         --systems "${OUTPUT}/${LEVEL}/${LG}/"*"/${SPLIT}_beam${BEAM_WIDTH}.predictions" \
-                        --output="${OUTPUTPATH}"
+                        --output "${OUTPUTPATH}"
 	        done
         done
     done
@@ -98,7 +98,7 @@ evaluate() {
         for LEVEL in low medium high; do
             echo "Level: ${LEVEL}"
                 python ${EVALUATION}/./evaluate_all.py \
-                    "${OUTPUT}/"*"/"*"/ensemble/${SPLIT}_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
+                    "${OUTPUT}/${LEVEL}/"*"/ensemble/${SPLIT}_${MAX_ENSEMBLE_SIZE}ensemble.tsv"
             echo
         done
     done
@@ -110,11 +110,15 @@ main() {
     evaluate
 }
 
-while getopts "rt:" option; do
-    case "${option}" in 
+while getopts "rt:" OPTION; do
+    case "${OPTION}" in 
         t)
-            # Specifies target language for restraining
+            # Specifies target language for retraining.
             LANGS=${OPTARG}
+            for lang in ${LANGS}; do
+                echo "${OUTPUT}/"*"/${lang}"
+                find ${OUTPUT}/* -type d -name ${lang} -exec rm -rf {} +
+            done
             ;;
         r)  
             # Resets entire run. This will delete all prior data. 
@@ -133,7 +137,7 @@ while getopts "rt:" option; do
             ;;
     esac
 done
-if [ ! -d "${OUTPUT}" ]
+if [[ ! -d "${OUTPUT}" ]]
     # For starting a new run.
     then
         mkdir ${OUTPUT}

--- a/baseline/trans/ensembling.py
+++ b/baseline/trans/ensembling.py
@@ -1,4 +1,5 @@
 """Performs majority-vote ensembling over files with predictions."""
+
 from typing import TextIO
 
 import argparse
@@ -78,25 +79,17 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-
     logging.basicConfig(level="INFO", format="%(levelname)s: %(message)s")
 
-    parser = argparse.ArgumentParser(
-        description="Produce a majority-vote output file."
-    )
-    parser.add_argument(
-        "--gold", type=str, required=True, help="Path to gold data."
-    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gold", required=True, help="path to gold data")
     parser.add_argument(
         "--systems",
-        type=str,
         required=True,
         nargs="+",
-        help="Path to systems' data.",
+        help="path to system data",
     )
     parser.add_argument(
-        "--output", type=str, required=True, help="Output directory."
+        "--output", required=True, help="output directory path"
     )
-
-    args = parser.parse_args()
-    main(args)
+    main(parser.parse_args())

--- a/baseline/trans/train.py
+++ b/baseline/trans/train.py
@@ -1,4 +1,5 @@
 """Trains a grapheme-to-phoneme neural transducer."""
+
 from typing import List
 
 import argparse
@@ -18,9 +19,6 @@ from trans import sed
 from trans import transducer
 from trans import utils
 from trans import vocabulary
-
-
-random.seed(1)
 
 
 def decode(
@@ -63,7 +61,8 @@ def inverse_sigmoid_schedule(k: int):
     return lambda epoch: (1 - k / (k + np.exp(epoch / k)))
 
 
-def main(args: argparse.Namespace):
+def main(args: argparse.Namespace) -> None:
+    random.seed(1)
 
     dargs = args.__dict__
     for key, value in dargs.items():
@@ -281,105 +280,97 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-
     logging.basicConfig(level="INFO", format="%(levelname)s: %(message)s")
-
-    parser = argparse.ArgumentParser(
-        description="Train a g2p neural transducer."
-    )
-
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--dynet-seed", type=int, required=True, help="DyNET random seed."
+        "--dynet-seed", type=int, required=True, help="DyNET random seed"
     )
     parser.add_argument(
-        "--dynet-mem", type=int, default=1000, help="Allocate MEM MB to DyNET."
+        "--dynet-mem",
+        type=int,
+        default=1000,
+        help="megabytes of memory to allocate to DyNET",
     )
     parser.add_argument(
-        "--dynet-autobatch", type=int, help="Perform automatic minibatching."
+        "--dynet-autobatch", type=int, help="perform automatic minibatching"
     )
     parser.add_argument(
-        "--train", type=str, required=True, help="Path to train set data."
+        "--train", required=True, help="path to train set data"
     )
     parser.add_argument(
-        "--dev", type=str, required=True, help="Path to development set data."
+        "--dev", required=True, help="path to development set data"
     )
+    parser.add_argument("--test", help="path to development set data")
     parser.add_argument(
-        "--test", type=str, help="Path to development set data."
-    )
-    parser.add_argument(
-        "--output", type=str, required=True, help="Output directory."
+        "--output", required=True, help="output directory path"
     )
     parser.add_argument(
         "--nfd",
         action="store_true",
-        help="Train on NFD-normalized data. Write out in NFC.",
+        help="use NFD normalization internally (output is still NFC)",
     )
     parser.add_argument(
         "--char-dim",
         type=int,
         default=100,
-        help="Character peak_embedding dimension.",
+        help="character peak_embedding dimension",
     )
     parser.add_argument(
         "--action-dim",
         type=int,
         default=100,
-        help="Action peak_embedding dimension.",
+        help="action peak_embedding dimension",
     )
     parser.add_argument(
         "--enc-hidden-dim",
         type=int,
         default=200,
-        help="Encoder LSTM state dimension.",
+        help="encoder LSTM state dimension",
     )
     parser.add_argument(
         "--dec-hidden-dim",
         type=int,
         default=200,
-        help="Decoder LSTM state dimension.",
+        help="decoder LSTM state dimension",
     )
     parser.add_argument(
         "--enc-layers",
         type=int,
         default=1,
-        help="Number of encoder LSTM layers.",
+        help="number of encoder LSTM layers",
     )
     parser.add_argument(
         "--dec-layers",
         type=int,
         default=1,
-        help="Number of decoder LSTM layers.",
+        help="number of decoder LSTM layers",
     )
     parser.add_argument(
         "--beam-width",
         type=int,
         default=4,
-        help="Beam width for beam search decoding.",
+        help="beam width for beam search decoding",
     )
     parser.add_argument(
         "--k",
         type=int,
         default=1,
-        help="k for inverse sigmoid rollin schedule.",
+        help="inverse sigmoid rollin schedule hyperparameter",
     )
     parser.add_argument(
         "--patience",
         type=int,
         default=12,
-        help="Maximal patience for early stopping.",
+        help="patience for early stopping",
     )
     parser.add_argument(
         "--epochs",
         type=int,
         default=60,
-        help="Maximal number of training epochs.",
+        help="maximum number of training epochs",
     )
+    parser.add_argument("--batch-size", type=int, default=5, help="batch size")
     parser.add_argument(
-        "--batch-size", type=str, default=5, help="Batch size."
+        "--sed-em-iterations", type=int, default=10, help="SED EM iterations"
     )
-    parser.add_argument(
-        "--sed-em-iterations", type=int, default=10, help="SED EM iterations."
-    )
-
-    args = parser.parse_args()
-    main(args)
+    main(parser.parse_args())


### PR DESCRIPTION
Tweaked script to be more accommodating to interrupted training. Added flags to make resetting training more explicit and allowed passing of specific languages for retraining. Will also now skip training for languages that already have evidence of prior training. 

New pipeline for an interrupted will simply require restarting the sweep and running targeted sweep `sweep -t` on any incomplete languages. 